### PR TITLE
refactor: only bsc is enabled in mainnet

### DIFF
--- a/src/constants/chains.ts
+++ b/src/constants/chains.ts
@@ -11,14 +11,14 @@ import type { Chain } from 'wagmi';
 import { buildConfig } from './build';
 import { xrplSidechain } from './custom-chains';
 
-// const ethChains = [ethereum, goerli];
+const ethChains = [ethereum, goerli];
 const bnbChains = [bsc, bscTestnet];
 const maticChains = [polygon, polygonMumbai];
 const xrplChains = [xrplSidechain];
 
-const mainnetChains: Chain[] = [/* ethereum */ bsc, polygon];
+const mainnetChains: Chain[] = [/* ethereum */ bsc /*polygon*/];
 const testnetChains: Chain[] = [
-  /* goerli, */
+  goerli,
   bscTestnet,
   polygonMumbai,
   xrplSidechain,
@@ -27,7 +27,7 @@ const testnetChains: Chain[] = [
 export function getCustomChainId(chain: Chain | undefined) {
   if (!chain) return undefined;
 
-  // if (ethChains.some(c => c.id === chain.id)) return 'eth';
+  if (ethChains.some(c => c.id === chain.id)) return 'eth';
   if (bnbChains.some(c => c.id === chain.id)) return 'bnb';
   if (maticChains.some(c => c.id === chain.id)) return 'matic';
   if (xrplChains.some(c => c.id === chain.id)) return 'xrpl';


### PR DESCRIPTION
# Updates on supported chains
Mainnet (Staging) disabled Polygon, and Ethereum, only BNB Chain is enabled.